### PR TITLE
Move second column below first in thin displays

### DIFF
--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -35,7 +35,7 @@ header p {
     display: flex;
     flex-direction: column;
     align-items: center;
-    padding: 20px 0;
+    padding-top: 20px;
 }
 
 #side-info > img {
@@ -70,6 +70,10 @@ header p {
 
 #server-p {
     text-align: center;
+}
+
+#about-me {
+    padding-left: 50px;
 }
 
 #about-me h2 {
@@ -107,4 +111,14 @@ header p {
     position: absolute;
     bottom: 12px;
     padding: 6px;
+}
+
+@media screen and (max-width: 800px) {
+    #content {
+        grid-template-columns: 100%;
+    }
+
+    #about-me {
+        padding-left: 0;
+    }
 }


### PR DESCRIPTION
Hi Claire! This PR moves the right column below the left one when opened in a device with a width less than 800px. Like this:

![screenshot](https://user-images.githubusercontent.com/42523716/109741316-6e3f0e80-7b92-11eb-8fe3-09de41a3f9c2.png)
